### PR TITLE
Backfill channels on startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Electrogram is a [SlackHQ](https://slack.com/) desktop client written in [Electr
 
 ![](https://cloud.githubusercontent.com/assets/38/8126814/ab1af59c-10a6-11e5-8de0-74e68b688b3d.gif)
  
-### Chat Tokens
+## Chat Tokens
 
 Grab an authorization token from the [Slack Docs](https://api.slack.com/web). You can provide an array of tokens for each slack subdomain that you're a part of. Add them to `~/.peonies.json`.
 
@@ -22,12 +22,12 @@ Grab an authorization token from the [Slack Docs](https://api.slack.com/web). Yo
 }
 ```
 
-### Running
+## Running
 
     % npm i
     % electron .
 
-### Testing
+## Testing
 
 You can test by running the following.
     

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "react": "^0.13.3",
     "react-tools": "^0.13.3",
     "reactify": "^1.1.1",
-    "slack-client-atmos": "~1.4.2"
+    "slack-client-atmos": "~1.4.4"
   },
   "devDependencies": {
     "chai": "~1.0.3",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "react": "^0.13.3",
     "react-tools": "^0.13.3",
     "reactify": "^1.1.1",
-    "slack-client": "1.3.1"
+    "slack-client": "https://github.com/lstoll/node-slack-client#peonies_tweaks"
   },
   "devDependencies": {
     "chai": "~1.0.3",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "react": "^0.13.3",
     "react-tools": "^0.13.3",
     "reactify": "^1.1.1",
-    "slack-client": "https://github.com/lstoll/node-slack-client#peonies_tweaks"
+    "slack-client": "~1.4.1"
   },
   "devDependencies": {
     "chai": "~1.0.3",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "react": "^0.13.3",
     "react-tools": "^0.13.3",
     "reactify": "^1.1.1",
-    "slack-client": "~1.4.1"
+    "slack-client-atmos": "~1.4.2"
   },
   "devDependencies": {
     "chai": "~1.0.3",

--- a/src/main.coffee
+++ b/src/main.coffee
@@ -14,7 +14,7 @@ chatApp = React.createElement App, {key: "global", connections: [ ] }
 tokenFile = "#{process.env.HOME}/.peonies.json"
 config = new Config tokenFile
 for token in config.tokens
-  connection = new SlackConnection(token, config.channels, document)
+  connection = new SlackConnection(token, document)
   connection.on "login", (conn, user, team) ->
     team = new React.createElement Team, {key: team.id, user: team, team: team, connection: conn, channels: []}
     chatApp.props.connections.push(team)
@@ -68,3 +68,8 @@ setTimeout ( ->
 
   React.render chatApp, document.getElementById("chat-app")
 ), 500
+
+setTimeout ( ->
+  connection.client.autoMark = true
+  React.render chatApp, document.getElementById("chat-app")
+), 5000

--- a/src/main.coffee
+++ b/src/main.coffee
@@ -28,8 +28,6 @@ for token in config.tokens
             channel.fetchHistory()
 
     React.render chatApp, document.getElementById("chat-app")
-  connection.on "backfill", (conn, team) ->
-    console.log "BACK FILLING #{team.name}"
 
   connection.on "message", (conn, msg) ->
     console.log "Message Received: #{msg.ts} - #{msg.type}:#{msg.subtype} - #{msg.text}"

--- a/src/main.coffee
+++ b/src/main.coffee
@@ -14,11 +14,23 @@ chatApp = React.createElement App, {key: "global", connections: [ ] }
 tokenFile = "#{process.env.HOME}/.peonies.json"
 config = new Config tokenFile
 for token in config.tokens
-  connection = new SlackConnection(token, document)
+  connection = new SlackConnection(token, config.channels, document)
   connection.on "login", (conn, user, team) ->
     team = new React.createElement Team, {key: team.id, user: team, team: team, connection: conn, channels: []}
     chatApp.props.connections.push(team)
+
+    for preferredChannel in config.channels
+      console.log preferredChannel
+      [teamName, channelName] = preferredChannel.name.split("#")
+      if teamName is team.props.team.name
+        for channelId, channel of conn.client.channels
+          if channelName is channel.name
+            channel.fetchHistory()
+
     React.render chatApp, document.getElementById("chat-app")
+  connection.on "backfill", (conn, team) ->
+    console.log "BACK FILLING #{team.name}"
+
   connection.on "message", (conn, msg) ->
     console.log "Message Received: #{msg.ts} - #{msg.type}:#{msg.subtype} - #{msg.text}"
 

--- a/src/main.coffee
+++ b/src/main.coffee
@@ -20,7 +20,6 @@ for token in config.tokens
     chatApp.props.connections.push(team)
 
     for preferredChannel in config.channels
-      console.log preferredChannel
       [teamName, channelName] = preferredChannel.name.split("#")
       if teamName is team.props.team.name
         for channelId, channel of conn.client.channels
@@ -47,6 +46,7 @@ for token in config.tokens
       user = team.props.connection.client.users[msg.user]
       if user?
         message = React.createElement Message, {key: msg.ts, msg: msg, user: user, channel: channel }
+        channel.props.messages.shift() if channel.props.messages.length > 50
         channel.props.messages.push(message)
 
         console.log "#{msg._client.team.name} / #{channel.props.name} / #{user.name} - #{msg.text}"

--- a/src/react/app.coffee
+++ b/src/react/app.coffee
@@ -24,7 +24,7 @@ App = React.createClass
     if @props.connections?
       team = (team for team in @props.connections when team.props.team.name is teamName)[0]
       for channelId, info of team.props.connection.client.channels
-        if channelName == info .name
+        if channelName == info.name
           channel = (channel for channel in team.props.channels when channel.key == channelId)[0]
 
           unless channel?

--- a/src/slack_connection.coffee
+++ b/src/slack_connection.coffee
@@ -1,4 +1,4 @@
-SlackClient  = require 'slack-client'
+SlackClient  = require 'slack-client-atmos'
 EventEmitter = require 'events'
 
 class SlackConnection extends EventEmitter

--- a/src/slack_connection.coffee
+++ b/src/slack_connection.coffee
@@ -3,7 +3,7 @@ EventEmitter = require 'events'
 
 class SlackConnection extends EventEmitter
   constructor: (@token, @document) ->
-    @client = new SlackClient @token, true, true
+    @client = new SlackClient @token, true, false
 
     @client.on 'open', @.open
     @client.on 'close', @.close

--- a/src/slack_connection.coffee
+++ b/src/slack_connection.coffee
@@ -28,6 +28,10 @@ class SlackConnection extends EventEmitter
 
   login: (self, team) =>
     @emit "login", @, self, team
+    console.log @client.channels[0]
+    for k of @client.channels
+      chan = @client.channels[k]
+      chan.fetchHistory()
 
   message: (msg) =>
     @emit "message", @, msg

--- a/src/slack_connection.coffee
+++ b/src/slack_connection.coffee
@@ -28,10 +28,6 @@ class SlackConnection extends EventEmitter
 
   login: (self, team) =>
     @emit "login", @, self, team
-    console.log @client.channels[0]
-    for k of @client.channels
-      chan = @client.channels[k]
-      chan.fetchHistory()
 
   message: (msg) =>
     @emit "message", @, msg


### PR DESCRIPTION
This requires https://github.com/slackhq/node-slack-client/pull/45 to get merged or finding a sane way to hack on the slack-client stuff. I couldn't get @lstoll's npm fork to work.

Right now this only backfills channels you've configured in your `~/.peonies.json`. It also doesn't seem to render anything until you resize. This at least lets you see shit on startup but is obviously going to require more work.