### PR TITLE
Try to format slack-style links

### DIFF
--- a/src/electron_app.coffee
+++ b/src/electron_app.coffee
@@ -1,5 +1,6 @@
 App = require 'app'
 BrowserWindow = require 'browser-window'
+Shell = require 'shell'
 
 mainWindow = null
 
@@ -19,3 +20,9 @@ App.on 'ready', ->
     # in an array if your app supports multi windows, this is the time
     # when you should delete the corresponding element.
     mainWindow = null
+
+
+  mainWindow.webContents.on 'new-window', (e, url) ->
+    if url.match /^https?\:\/\//
+      Shell.openExternal(url)
+    e.preventDefault()

--- a/src/main.coffee
+++ b/src/main.coffee
@@ -13,4 +13,3 @@ setTimeout ( ->
 
   React.render app.reactElement, document.getElementById("chat-app")
 ), 500
-

--- a/src/react/messages/text_message.coffee
+++ b/src/react/messages/text_message.coffee
@@ -1,16 +1,29 @@
 MessageElement = require "../message"
 
 class TextMessage extends MessageElement
+
   render: ->
     <div className="message">
       <span className="avatar">
         <img src={ @userAvatarImage() } />
       </span>
       <h4 className="author">{ @userName() }</h4>
-      <div className="content text">{ @body() }</div>
+      <div className="content text" dangerouslySetInnerHTML={{__html: @body()}}/>
     </div>
 
   body: () ->
-    @emojify(@props.parent.body())
+    @emojify(@slackify(@props.parent.body()))
+
+  slackify: (text) ->
+    loop
+      match = text.match(/\<((?!a href|\/a).+?)\>/)
+      break unless match
+
+      [target, readableName] = match[1].split(/\|/)
+      readableName ?= target
+
+      text = text.replace match[0], "<a href=\"#{target}\" class=\"external\" target=\"_blank\">#{readableName}</a>"
+    text
+
 
 module.exports = TextMessage


### PR DESCRIPTION
Slack does some normalization of URLs and links, so clients get them back like  `<http://foo.com/>`. This tries to parse them out, and replace them with `<a>`s. https://api.slack.com/docs/formatting has more details about the format.

This isn't quite working yet, as clicking on a link tries to open it in the electrogram window, rather than a browser, which is definitely a problem. Should be able to use https://github.com/atom/electron/blob/master/docs/api/shell.md#shellopenexternalurl to open in a browser, but I'm not sure where the best place is going to add a click handler.

Worth noting that this is used for user mentions and channels too, so will probably need to handle those at some point too.

Also, this may make sense as a react component and/or mixin, but... still learning that stuff.